### PR TITLE
Migrate dependencies to version catalogs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,12 +34,12 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'ai.elimu:content-provider:1.3.22' // https://jitpack.io/#ai.elimu/content-provider
+    implementation libs.elimu.content.provider // https://jitpack.io/#ai.elimu/content-provider
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
 
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation libs.androidx.junit
+    androidTestImplementation libs.androidx.espresso
 }
 
 publishing {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.8.1'
+        classpath libs.agp
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,19 @@
+[versions]
+junit = "4.13.2"
+androidXJunit = "1.2.1"
+elimuContentProvider = "1.3.22"
+
+androidXEspresso = "3.6.1"
+agp = "8.8.2"
+kotlin = "2.1.21"
+
+[libraries]
+androidx-espresso = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidXEspresso" }
+agp = { group = "com.android.tools.build", name = "gradle", version.ref = "agp" }
+elimu-content-provider = { group = "ai.elimu", name = "content-provider", version.ref = "elimuContentProvider" }
+
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidXJunit" }
+
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }


### PR DESCRIPTION
Migrate dependencies to version catalogs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Centralized dependency version management using a version catalog for improved consistency and maintainability.
	- Updated build scripts to reference dependencies via catalog aliases instead of hardcoded version strings.
	- Added a new version catalog file to manage library and plugin versions in one place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->